### PR TITLE
Fix navbar portfolio link by adding Featured Work section id

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@ src="https://www.facebook.com/tr?id=2202404140236620&ev=PageView&noscript=1"
   </div>
 </section>
 
-<section class="section">
+<section class="section" id="Featuredwork">
   <div class="container">
     <h2 class="section-title">Featured Work</h2>
     <div class="carousel-wrapper" id="carousel">


### PR DESCRIPTION
## Summary
- add `id="Featuredwork"` to Featured Work section so the navigation bar portfolio link targets it

## Testing
- `node -e "const fs=require('fs'); const html=fs.readFileSync('index.html','utf8'); const hasId=/id=\\"Featuredwork\\"/.test(html); const hasLink=/<a\\s+href=\\"#Featuredwork\\"/.test(html); console.log('hasId',hasId); console.log('hasLink',hasLink);"`


------
https://chatgpt.com/codex/tasks/task_e_68c7cc0f20fc832d861d1cfe7fd585e2